### PR TITLE
fetch images from body if head has no preview image

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,11 +44,13 @@ function parse (html, url) {
   const favicon = getFavicon(head, url)
   const title = getTitle(head)
   const meta = getMeta(head)
+  const img = getImageUrls(html)
 
   return {
     favicon,
     title,
     meta,
+    img,
     url
   }
 }
@@ -117,6 +119,23 @@ function getMeta (html) {
   }
 
   return meta
+}
+
+function getImageUrls(html) {
+  const imgUrls = [];
+  const regex = /<img[^>]+src=["']([^"']+)["']/g;
+  let match;
+
+  // Use a regular expression to find all <img> tags and extract the src attribute
+  while ((match = regex.exec(html)) !== null) {
+    imgUrls.push(match[1]); // Push the src URL into the array
+  }
+
+  return imgUrls;
+
+
+  // Return the array of image URLs
+  return imgUrls;
 }
 
 function getTitle (html) {


### PR DESCRIPTION
Netflix url has no open graph reference to the image, other apps can fetch the images from body.

URL : https://netflix.com

Please close the PR if this is not required

![image](https://github.com/user-attachments/assets/db004b68-2eb2-4eb8-be3a-1e177ea89246)
